### PR TITLE
Executing customRequests in Playwright session

### DIFF
--- a/lib/config/constants.js
+++ b/lib/config/constants.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const env = process.env.NODE_ENV || 'dev';
-const customRequestEnabled = process.env.CUSTOM_REQUEST_ENABLED || false
+const customRequestEnabled = process.env.CUSTOM_REQUEST_ENABLED === 'true'
 const config = require('./config.json')[env];
 const logger = require('../util/loggerFactory');
 const {

--- a/lib/config/constants.js
+++ b/lib/config/constants.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const env = process.env.NODE_ENV || 'dev';
+const customRequestEnabled = process.env.CUSTOM_REQUEST_ENABLED || false
 const config = require('./config.json')[env];
 const logger = require('../util/loggerFactory');
 const {
@@ -252,6 +253,7 @@ module.exports = {
   kEnableIncomingQueue,
   kEnableOutgoingQueue,
   kUpstreamRestart,
+  customRequestEnabled,
   PROXY_LOCKED,
   PROXY_RESTART,
   HTTPLOG

--- a/lib/config/constants.js
+++ b/lib/config/constants.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const env = process.env.NODE_ENV || 'dev';
-const customRequestEnabled = process.env.CUSTOM_REQUEST_ENABLED === 'true'
+const customRequestEnabled = process.env.CUSTOM_REQUEST_ENABLED === 'true';
 const config = require('./config.json')[env];
 const logger = require('../util/loggerFactory');
 const {
@@ -256,5 +256,5 @@ module.exports = {
   customRequestEnabled,
   PROXY_LOCKED,
   PROXY_RESTART,
-  HTTPLOG
+  HTTPLOG,
 };

--- a/lib/core/CustomRequestHandler.js
+++ b/lib/core/CustomRequestHandler.js
@@ -2,13 +2,17 @@
 
 const logger = require('../util/loggerFactory');
 
-/*
-This class handles the custom requests made to existing playwright connection.
-This is kept as Singleton class because we want to maintain a map of commands for which
-we can resolve the response once we receive from Playwright server.
-Please don't change the singleton behaviour of this class.
-*/
+/**
+ * Handles the custom requests made to existing playwright connection.
+ * This class is implemented as a Singleton to maintain a map of commands for which
+ * responses can be resolved once received from the Playwright server.
+ * @class
+ */
 class CustomRequestHandler {
+  /**
+   * Creates an instance of CustomRequestHandler.
+   * @constructor
+   */
   constructor() {
     if (!CustomRequestHandler.instance) {
       // Initialize the instance if it doesn't exist
@@ -19,7 +23,11 @@ class CustomRequestHandler {
     // Return the existing instance if it already exists
     return CustomRequestHandler.instance;
   }
-  // Static method to get the single instance of the class
+
+  /**
+   * Static method to get the single instance of the class.
+   * @returns {CustomRequestHandler} The single instance of the CustomRequestHandler class.
+   */
   static getInstance() {
     if (!CustomRequestHandler.instance) {
       // Create a new instance if it doesn't exist
@@ -29,6 +37,10 @@ class CustomRequestHandler {
     return CustomRequestHandler.instance;
   }
 
+  /**
+   * Checks if the custom request list is empty.
+   * @returns {boolean} Returns true if the custom request list is empty, otherwise false.
+   */
   isCustomRequestListEmpty() {
     for (const prop in this.customRequestList) {
       if (this.customRequestList.hasOwnProperty(prop)) {
@@ -39,11 +51,10 @@ class CustomRequestHandler {
     return true;
   }
 
-  // only for specs purpose, don't use it in code.
-  static resetInstance() {
-    CustomRequestHandler.instance = null;
-  }
-  // Method to add an item to the list
+  /**
+   * Adds an item to the custom request list.
+   * @param {string} request_id - The ID of the request to be added.
+   */
   addCustomRequest(request_id) {
     let resolveFunc;
     let rejectFunc;
@@ -58,9 +69,23 @@ class CustomRequestHandler {
     };
     logger.info(`Added request '${request_id}' to the customRequestList.`);
   }
-  // Method to get the list items
+
+  /**
+   * Gets the items in the custom request list.
+   * @returns {Object} The custom request list.
+   */
   getList() {
     return this.customRequestList;
   }
+
+  /**
+   * Resets the instance of the CustomRequestHandler class.
+   * Only for testing purposes. Do not use it in production code.
+   * @static
+   */
+  static resetInstance() {
+    CustomRequestHandler.instance = null;
+  }
 }
+
 module.exports = CustomRequestHandler;

--- a/lib/core/CustomRequestHandler.js
+++ b/lib/core/CustomRequestHandler.js
@@ -2,6 +2,12 @@
 
 const logger = require('../util/loggerFactory');
 
+/*
+This class handles the custom requests made to existing playwright connection.
+This is kept as Singleton class because we want to maintain a map of commands for which
+we can resolve the response once we receive from Playwright server.
+Please don't change the singleton behaviour of this class.
+*/
 class CustomRequestHandler {
   constructor() {
     if (!CustomRequestHandler.instance) {

--- a/lib/core/CustomRequestHandler.js
+++ b/lib/core/CustomRequestHandler.js
@@ -28,6 +28,21 @@ class CustomRequestHandler {
     // Return the existing instance
     return CustomRequestHandler.instance;
   }
+
+  isCustomRequestListEmpty() {
+    for (const prop in this.customRequestList) {
+      if (this.customRequestList.hasOwnProperty(prop)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  // only for specs purpose, don't use it in code.
+  static resetInstance() {
+    CustomRequestHandler.instance = null;
+  }
   // Method to add an item to the list
   addCustomRequest(request_id) {
     let resolveFunc;

--- a/lib/core/CustomRequestHandler.js
+++ b/lib/core/CustomRequestHandler.js
@@ -39,8 +39,8 @@ class CustomRequestHandler {
     this.customRequestList[request_id] = {
       resolve: resolveFunc,
       reject: rejectFunc,
-      promise: promise
-    }
+      promise: promise,
+    };
     logger.info(`Added request '${request_id}' to the customRequestList.`);
   }
   // Method to get the list items

--- a/lib/core/CustomRequestHandler.js
+++ b/lib/core/CustomRequestHandler.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const logger = require('../util/loggerFactory');
+
+class CustomRequestHandler {
+  constructor() {
+    if (!CustomRequestHandler.instance) {
+      // Initialize the instance if it doesn't exist
+      CustomRequestHandler.instance = this;
+      // Initialize the map {} as part of the instance
+      this.customRequestList = {};
+    }
+    // Return the existing instance if it already exists
+    return CustomRequestHandler.instance;
+  }
+  // Static method to get the single instance of the class
+  static getInstance() {
+    if (!CustomRequestHandler.instance) {
+      // Create a new instance if it doesn't exist
+      CustomRequestHandler.instance = new CustomRequestHandler();
+    }
+    // Return the existing instance
+    return CustomRequestHandler.instance;
+  }
+  // Method to add an item to the list
+  addCustomRequest(request_id) {
+    let resolveFunc;
+    let rejectFunc;
+    let promise = new Promise((resolve, reject) => {
+      resolveFunc = resolve;
+      rejectFunc = reject;
+    });
+    this.customRequestList[request_id] = {
+      resolve: resolveFunc,
+      reject: rejectFunc,
+      promise: promise
+    }
+    logger.info(`Added request '${request_id}' to the customRequestList.`);
+  }
+  // Method to get the list items
+  getList() {
+    return this.customRequestList;
+  }
+}
+module.exports = CustomRequestHandler;

--- a/lib/core/IncomingWebSocket.js
+++ b/lib/core/IncomingWebSocket.js
@@ -117,8 +117,7 @@ class IncomingWebSocket extends EventEmitter {
    */
   close(code, msg) {
     this.teardown = true;
-    if(code >= 1000 && code < 1004)
-      this.socket.close(code, msg);
+    if (code >= 1000 && code < 1004) this.socket.close(code, msg);
     this.socket.terminate();
   }
 

--- a/lib/core/OutgoingWebSocket.js
+++ b/lib/core/OutgoingWebSocket.js
@@ -113,10 +113,10 @@ class OutgoingWebSocket extends EventEmitter {
     let resp;
     try {
       resp = JSON.parse(msg);
-      if (customReqInstance.getList().hasOwnProperty(resp?.id)) {
+      if (resp && customReqInstance.getList().hasOwnProperty(resp.id)) {
         customReqInstance.customRequestList[resp.id].resolve(msg)
+        return;
       }
-      return;
     } catch (error) {
       console.error('Error parsing JSON:', error);
     }
@@ -153,10 +153,10 @@ class OutgoingWebSocket extends EventEmitter {
     let resp;
     try {
       resp = JSON.parse(msg);
-      if (customReqInstance.getList().hasOwnProperty(resp?.id)) {
+      if (resp && customReqInstance.getList().hasOwnProperty(resp.id)) {
         customReqInstance.customRequestList[resp.id].reject(error)
+        return;
       }
-      return;
     } catch (error) {
       console.error('Error parsing JSON:', error);
     }

--- a/lib/core/OutgoingWebSocket.js
+++ b/lib/core/OutgoingWebSocket.js
@@ -24,12 +24,12 @@ const {
   PROXY_RESTART,
   DISALLOWED_HEADERS,
   OUTGOING,
-  customRequestEnabled
+  customRequestEnabled,
 } = require('../config/constants');
 const { extractConnectionId } = require('../util/util');
 const { incrReconnectionCount } = require('../util/metrics');
 const { isNotUndefined } = require('../util/typeSanity');
-const CustomRequestHandler = require('./CustomRequestHandler')
+const CustomRequestHandler = require('./CustomRequestHandler');
 
 /**
  * Outgoing WebSocket connection is the connection object
@@ -110,13 +110,13 @@ class OutgoingWebSocket extends EventEmitter {
       return;
     }
 
-    if(customRequestEnabled) {
+    if (customRequestEnabled) {
       const customReqInstance = CustomRequestHandler.getInstance();
       let resp;
       try {
         resp = JSON.parse(msg);
         if (resp && customReqInstance.getList().hasOwnProperty(resp.id)) {
-          customReqInstance.customRequestList[resp.id].resolve(msg)
+          customReqInstance.customRequestList[resp.id].resolve(msg);
           return;
         }
       } catch (error) {
@@ -152,13 +152,13 @@ class OutgoingWebSocket extends EventEmitter {
    * Triggers when error occured on socket.
    */
   errorHandler(error) {
-    if(customRequestEnabled) {
+    if (customRequestEnabled) {
       const customReqInstance = CustomRequestHandler.getInstance();
       let resp;
       try {
-        resp = JSON.parse(msg);
+        resp = JSON.parse(error);
         if (resp && customReqInstance.getList().hasOwnProperty(resp.id)) {
-          customReqInstance.customRequestList[resp.id].reject(error)
+          customReqInstance.customRequestList[resp.id].reject(error);
           return;
         }
       } catch (error) {
@@ -193,12 +193,9 @@ class OutgoingWebSocket extends EventEmitter {
    *  Closes the socket connection.
    */
   close(code, msg) {
-    if (code == 1006)
-      this.socket.terminate();
-    else if (code == 1005)
-      this.socket.close();
-    else
-      this.socket.close(code, msg);
+    if (code == 1006) this.socket.terminate();
+    else if (code == 1005) this.socket.close();
+    else this.socket.close(code, msg);
   }
 
   /**

--- a/lib/core/OutgoingWebSocket.js
+++ b/lib/core/OutgoingWebSocket.js
@@ -24,6 +24,7 @@ const {
   PROXY_RESTART,
   DISALLOWED_HEADERS,
   OUTGOING,
+  customRequestEnabled
 } = require('../config/constants');
 const { extractConnectionId } = require('../util/util');
 const { incrReconnectionCount } = require('../util/metrics');
@@ -109,16 +110,18 @@ class OutgoingWebSocket extends EventEmitter {
       return;
     }
 
-    const customReqInstance = CustomRequestHandler.getInstance();
-    let resp;
-    try {
-      resp = JSON.parse(msg);
-      if (resp && customReqInstance.getList().hasOwnProperty(resp.id)) {
-        customReqInstance.customRequestList[resp.id].resolve(msg)
-        return;
+    if(customRequestEnabled) {
+      const customReqInstance = CustomRequestHandler.getInstance();
+      let resp;
+      try {
+        resp = JSON.parse(msg);
+        if (resp && customReqInstance.getList().hasOwnProperty(resp.id)) {
+          customReqInstance.customRequestList[resp.id].resolve(msg)
+          return;
+        }
+      } catch (error) {
+        console.error('Error parsing JSON:', error);
       }
-    } catch (error) {
-      console.error('Error parsing JSON:', error);
     }
     this.emit(kMessageReceived, msg);
   }
@@ -149,16 +152,18 @@ class OutgoingWebSocket extends EventEmitter {
    * Triggers when error occured on socket.
    */
   errorHandler(error) {
-    const customReqInstance = CustomRequestHandler.getInstance();
-    let resp;
-    try {
-      resp = JSON.parse(msg);
-      if (resp && customReqInstance.getList().hasOwnProperty(resp.id)) {
-        customReqInstance.customRequestList[resp.id].reject(error)
-        return;
+    if(customRequestEnabled) {
+      const customReqInstance = CustomRequestHandler.getInstance();
+      let resp;
+      try {
+        resp = JSON.parse(msg);
+        if (resp && customReqInstance.getList().hasOwnProperty(resp.id)) {
+          customReqInstance.customRequestList[resp.id].reject(error)
+          return;
+        }
+      } catch (error) {
+        console.error('Error parsing JSON:', error);
       }
-    } catch (error) {
-      console.error('Error parsing JSON:', error);
     }
     this.emit(kError, error);
   }

--- a/lib/core/OutgoingWebSocket.js
+++ b/lib/core/OutgoingWebSocket.js
@@ -120,7 +120,7 @@ class OutgoingWebSocket extends EventEmitter {
           return;
         }
       } catch (error) {
-        console.error('Error parsing JSON:', error);
+        logger.error(`Error parsing JSON: ${error}`);
       }
     }
     this.emit(kMessageReceived, msg);
@@ -162,7 +162,7 @@ class OutgoingWebSocket extends EventEmitter {
           return;
         }
       } catch (error) {
-        console.error('Error parsing JSON:', error);
+        logger.error(`Error parsing JSON: ${error}`);
       }
     }
     this.emit(kError, error);

--- a/lib/core/OutgoingWebSocket.js
+++ b/lib/core/OutgoingWebSocket.js
@@ -110,8 +110,8 @@ class OutgoingWebSocket extends EventEmitter {
       return;
     }
 
-    if (customRequestEnabled) {
-      const customReqInstance = CustomRequestHandler.getInstance();
+    const customReqInstance = CustomRequestHandler.getInstance();
+    if (customRequestEnabled && !customReqInstance.isCustomRequestListEmpty()) {
       let resp;
       try {
         resp = JSON.parse(msg);
@@ -152,8 +152,8 @@ class OutgoingWebSocket extends EventEmitter {
    * Triggers when error occured on socket.
    */
   errorHandler(error) {
-    if (customRequestEnabled) {
-      const customReqInstance = CustomRequestHandler.getInstance();
+    const customReqInstance = CustomRequestHandler.getInstance();
+    if (customRequestEnabled && !customReqInstance.isCustomRequestListEmpty()) {
       let resp;
       try {
         resp = JSON.parse(error);

--- a/lib/core/OutgoingWebSocket.js
+++ b/lib/core/OutgoingWebSocket.js
@@ -28,6 +28,7 @@ const {
 const { extractConnectionId } = require('../util/util');
 const { incrReconnectionCount } = require('../util/metrics');
 const { isNotUndefined } = require('../util/typeSanity');
+const CustomRequestHandler = require('./CustomRequestHandler')
 
 /**
  * Outgoing WebSocket connection is the connection object
@@ -107,6 +108,18 @@ class OutgoingWebSocket extends EventEmitter {
       this.emit(kEnableIncomingQueue);
       return;
     }
+
+    const customReqInstance = CustomRequestHandler.getInstance();
+    let resp;
+    try {
+      resp = JSON.parse(msg);
+      if (customReqInstance.getList().hasOwnProperty(resp?.id)) {
+        customReqInstance.customRequestList[resp.id].resolve(msg)
+      }
+      return;
+    } catch (error) {
+      console.error('Error parsing JSON:', error);
+    }
     this.emit(kMessageReceived, msg);
   }
 
@@ -136,6 +149,17 @@ class OutgoingWebSocket extends EventEmitter {
    * Triggers when error occured on socket.
    */
   errorHandler(error) {
+    const customReqInstance = CustomRequestHandler.getInstance();
+    let resp;
+    try {
+      resp = JSON.parse(msg);
+      if (customReqInstance.getList().hasOwnProperty(resp?.id)) {
+        customReqInstance.customRequestList[resp.id].reject(error)
+      }
+      return;
+    } catch (error) {
+      console.error('Error parsing JSON:', error);
+    }
     this.emit(kError, error);
   }
 
@@ -164,9 +188,9 @@ class OutgoingWebSocket extends EventEmitter {
    *  Closes the socket connection.
    */
   close(code, msg) {
-    if(code == 1006)
+    if (code == 1006)
       this.socket.terminate();
-    else if(code == 1005)
+    else if (code == 1005)
       this.socket.close();
     else
       this.socket.close(code, msg);

--- a/lib/core/Proxy.js
+++ b/lib/core/Proxy.js
@@ -90,12 +90,13 @@ class Proxy {
           customReqInstance.addCustomRequest(commandId);
 
           //Send to playwright server
-          const railsContext = this.contexts.get(commandId);
+          const railsId = [...this.contexts.keys()][0];
+          const railsContext = this.contexts.get(railsId);
           railsContext.outgoingSocket.send(JSON.stringify(command));
 
           //Get the resolved promise and returning it to end user
           customReqInstance.customRequestList[commandId].promise.then((result) => {
-            response.end(JSON.stringify({ "status": "success", "result": result }));
+            response.end(JSON.stringify({ "status": "success", "value": result }));
           });
         });
       } catch (e) {

--- a/lib/core/Proxy.js
+++ b/lib/core/Proxy.js
@@ -65,6 +65,7 @@ class Proxy {
       headers: request.headers,
     };
     logger.info(`${HTTPLOG} Received http request ${options}`);
+    logger.info(`Request ${JSON.stringify(request)}`);
     if (request.url.indexOf('/status') > -1) {
       response.writeHead(200, { 'content-type': 'application/json; charset=utf-8', 'accept': 'application/json', 'WWW-Authenticate': 'Basic realm="WS Reconnect Proxy"' });
       response.end(JSON.stringify({ "status": "Running" }));
@@ -82,7 +83,6 @@ class Proxy {
         // When the request ends, process the received data
         request.on('end', () => {
           body = JSON.parse(body);
-          response.writeHead(200, { 'content-type': 'application/json; charset=utf-8', 'accept': 'application/json', 'WWW-Authenticate': 'Basic realm="WS Reconnect Proxy"' });
           const command = body.command
           const commandId = body.command.id;
           //Create singleton object and map the command id with pending promise
@@ -96,8 +96,15 @@ class Proxy {
 
           //Get the resolved promise and returning it to end user
           customReqInstance.customRequestList[commandId].promise.then((result) => {
+            delete customReqInstance.customRequestList[commandId]
+            response.writeHead(200, { 'content-type': 'application/json; charset=utf-8', 'accept': 'application/json', 'WWW-Authenticate': 'Basic realm="WS Reconnect Proxy"' });
             response.end(JSON.stringify({ "status": "success", "value": result }));
-          });
+          }).catch((err) => {
+            delete customReqInstance.customRequestList[commandId]
+            response.writeHead(500, { 'content-type': 'application/json; charset=utf-8', 'accept': 'application/json', 'WWW-Authenticate': 'Basic realm="WS Reconnect Proxy"' });
+            response.end(JSON.stringify({ "status": "failure", "value": err }));
+          })
+          ;
         });
       } catch (e) {
         console.log('Error Resolving this', e);
@@ -105,6 +112,7 @@ class Proxy {
       return;
     }
     const proxyReq = http.request(options, (proxyResponse) => {
+      logger.info(`Response ${JSON.stringify(proxyResponse)}`);
       response.writeHead(proxyResponse.statusCode, proxyResponse.headers);
       proxyResponse.pipe(response, {
         end: true,

--- a/lib/core/Proxy.js
+++ b/lib/core/Proxy.js
@@ -23,6 +23,11 @@ const AlertManager = require('../util/AlertManager');
 const Instrumentation = require('../util/Instrumentation');
 const ErrorHandler = require('../util/ErrorHandler');
 const CustomRequestHandler = require('./CustomRequestHandler');
+const responseHeaders = {
+  'content-type': 'application/json; charset=utf-8',
+  accept: 'application/json',
+  'WWW-Authenticate': 'Basic realm="WS Reconnect Proxy"',
+}
 
 /**
  * Proxy is the entrypoint and instantiates the context among the socket connection.
@@ -111,32 +116,20 @@ class Proxy {
           customReqInstance.customRequestList[commandId].promise
             .then((result) => {
               delete customReqInstance.customRequestList[commandId];
-              response.writeHead(200, {
-                'content-type': 'application/json; charset=utf-8',
-                accept: 'application/json',
-                'WWW-Authenticate': 'Basic realm="WS Reconnect Proxy"',
-              });
+              response.writeHead(200, responseHeaders);
               response.end(
                 JSON.stringify({ status: 'success', value: result })
               );
             })
             .catch((err) => {
               delete customReqInstance.customRequestList[commandId];
-              response.writeHead(500, {
-                'content-type': 'application/json; charset=utf-8',
-                accept: 'application/json',
-                'WWW-Authenticate': 'Basic realm="WS Reconnect Proxy"',
-              });
+              response.writeHead(500, responseHeaders);
               response.end(JSON.stringify({ status: 'failure', value: err }));
             });
         });
       } catch (err) {
         logger.error(`Error while handling custom request ${err}`);
-        response.writeHead(500, {
-          'content-type': 'application/json; charset=utf-8',
-          accept: 'application/json',
-          'WWW-Authenticate': 'Basic realm="WS Reconnect Proxy"',
-        });
+        response.writeHead(500, responseHeaders);
         response.end(JSON.stringify({ status: 'failure', value: err.message }));
       }
       return;

--- a/lib/core/Proxy.js
+++ b/lib/core/Proxy.js
@@ -103,9 +103,9 @@ class Proxy {
           customReqInstance.addCustomRequest(commandId);
 
           //Send to playwright server
-          const railsId = [...this.contexts.keys()][0];
-          const railsContext = this.contexts.get(railsId);
-          railsContext.outgoingSocket.send(JSON.stringify(command));
+          const sessionId = [...this.contexts.keys()][0];
+          const sessionContext = this.contexts.get(sessionId);
+          sessionContext.outgoingSocket.send(JSON.stringify(command));
 
           //Get the resolved promise and returning it to end user
           customReqInstance.customRequestList[commandId].promise

--- a/lib/core/Proxy.js
+++ b/lib/core/Proxy.js
@@ -16,6 +16,7 @@ const { setMetrics } = require('../util/metrics');
 const AlertManager = require('../util/AlertManager');
 const Instrumentation = require('../util/Instrumentation');
 const ErrorHandler = require('../util/ErrorHandler');
+const CustomRequestHandler = require('./CustomRequestHandler')
 
 /**
  * Proxy is the entrypoint and instantiates the context among the socket connection.
@@ -64,9 +65,42 @@ class Proxy {
       headers: request.headers,
     };
     logger.info(`${HTTPLOG} Received http request ${options}`);
-    if(request.url.indexOf('/status') > -1){
-      response.writeHead(200, {'content-type': 'application/json; charset=utf-8', 'accept': 'application/json', 'WWW-Authenticate': 'Basic realm="WS Reconnect Proxy"'});
-      response.end(JSON.stringify({"status" : "Running"}));
+    if (request.url.indexOf('/status') > -1) {
+      response.writeHead(200, { 'content-type': 'application/json; charset=utf-8', 'accept': 'application/json', 'WWW-Authenticate': 'Basic realm="WS Reconnect Proxy"' });
+      response.end(JSON.stringify({ "status": "Running" }));
+      return;
+    } else if (request.url.indexOf('/customRequest') > -1 && request.method == 'POST') {
+      try {
+        logger.info(`Handling request to execute custom command in server`);
+        let body = '';
+
+        // Read data from the request
+        req.on('data', chunk => {
+          body += chunk.toString(); // Convert Buffer to string
+        });
+
+        // When the request ends, process the received data
+        req.on('end', () => {
+          body = JSON.parse(body);
+          response.writeHead(200, { 'content-type': 'application/json; charset=utf-8', 'accept': 'application/json', 'WWW-Authenticate': 'Basic realm="WS Reconnect Proxy"' });
+          const command = body.command
+          const commandId = body.command.id;
+          //Create singleton object and map the command id with pending promise
+          const customReqInstance = CustomRequestHandler.getInstance();
+          customReqInstance.addCustomRequest(commandId);
+
+          //Send to playwright server
+          const railsContext = this.contexts.get(commandId);
+          railsContext.outgoingSocket.send(JSON.stringify(command));
+
+          //Get the resolved promise and returning it to end user
+          customReqInstance.customRequestList[commandId].then((result) => {
+            response.end(JSON.stringify({ "status": "success", "result": result }));
+          });
+        });
+      } catch (e) {
+        console.log('Error Resolving this', e);
+      }
       return;
     }
     const proxyReq = http.request(options, (proxyResponse) => {
@@ -75,13 +109,14 @@ class Proxy {
         end: true,
       });
     });
-    proxyReq.on('error', (error)=>{
+
+    proxyReq.on('error', (error) => {
       logger.error(`${request.url} received error ${error}`);
     });
-    proxyReq.on('timeout', ()=>{
+    proxyReq.on('timeout', () => {
       logger.info(`${request.url} timed out`);
     });
-    proxyReq.on('drain', ()=>{
+    proxyReq.on('drain', () => {
       logger.info(`${request.url} drained out`);
     });
     request.pipe(proxyReq, {

--- a/lib/core/Proxy.js
+++ b/lib/core/Proxy.js
@@ -1,7 +1,13 @@
 'use strict';
 
 const WebSocket = require('ws');
-const { config, kCleanup, kAddNewContext, HTTPLOG, customRequestEnabled } = require('../config/constants');
+const {
+  config,
+  kCleanup,
+  kAddNewContext,
+  HTTPLOG,
+  customRequestEnabled,
+} = require('../config/constants');
 const logger = require('../util/loggerFactory');
 const Context = require('./Context');
 const {
@@ -16,7 +22,7 @@ const { setMetrics } = require('../util/metrics');
 const AlertManager = require('../util/AlertManager');
 const Instrumentation = require('../util/Instrumentation');
 const ErrorHandler = require('../util/ErrorHandler');
-const CustomRequestHandler = require('./CustomRequestHandler')
+const CustomRequestHandler = require('./CustomRequestHandler');
 
 /**
  * Proxy is the entrypoint and instantiates the context among the socket connection.
@@ -66,23 +72,31 @@ class Proxy {
     };
     logger.info(`${HTTPLOG} Received http request ${options}`);
     if (request.url.indexOf('/status') > -1) {
-      response.writeHead(200, { 'content-type': 'application/json; charset=utf-8', 'accept': 'application/json', 'WWW-Authenticate': 'Basic realm="WS Reconnect Proxy"' });
-      response.end(JSON.stringify({ "status": "Running" }));
+      response.writeHead(200, {
+        'content-type': 'application/json; charset=utf-8',
+        accept: 'application/json',
+        'WWW-Authenticate': 'Basic realm="WS Reconnect Proxy"',
+      });
+      response.end(JSON.stringify({ status: 'Running' }));
       return;
-    } else if ( customRequestEnabled && request.url.indexOf('/customRequest') > -1 && request.method == 'POST') {
+    } else if (
+      customRequestEnabled &&
+      request.url.indexOf('/customRequest') > -1 &&
+      request.method == 'POST'
+    ) {
       try {
         logger.info(`Handling request to execute custom command in server`);
         let body = '';
 
         // Read data from the request
-        request.on('data', chunk => {
+        request.on('data', (chunk) => {
           body += chunk.toString(); // Convert Buffer to string
         });
 
         // When the request ends, process the received data
         request.on('end', () => {
           body = JSON.parse(body);
-          const command = body.command
+          const command = body.command;
           const commandId = body.command.id;
           //Create singleton object and map the command id with pending promise
           const customReqInstance = CustomRequestHandler.getInstance();
@@ -94,19 +108,36 @@ class Proxy {
           railsContext.outgoingSocket.send(JSON.stringify(command));
 
           //Get the resolved promise and returning it to end user
-          customReqInstance.customRequestList[commandId].promise.then((result) => {
-            delete customReqInstance.customRequestList[commandId]
-            response.writeHead(200, { 'content-type': 'application/json; charset=utf-8', 'accept': 'application/json', 'WWW-Authenticate': 'Basic realm="WS Reconnect Proxy"' });
-            response.end(JSON.stringify({ "status": "success", "value": result }));
-          }).catch((err) => {
-            delete customReqInstance.customRequestList[commandId]
-            response.writeHead(500, { 'content-type': 'application/json; charset=utf-8', 'accept': 'application/json', 'WWW-Authenticate': 'Basic realm="WS Reconnect Proxy"' });
-            response.end(JSON.stringify({ "status": "failure", "value": err }));
-          })
-          ;
+          customReqInstance.customRequestList[commandId].promise
+            .then((result) => {
+              delete customReqInstance.customRequestList[commandId];
+              response.writeHead(200, {
+                'content-type': 'application/json; charset=utf-8',
+                accept: 'application/json',
+                'WWW-Authenticate': 'Basic realm="WS Reconnect Proxy"',
+              });
+              response.end(
+                JSON.stringify({ status: 'success', value: result })
+              );
+            })
+            .catch((err) => {
+              delete customReqInstance.customRequestList[commandId];
+              response.writeHead(500, {
+                'content-type': 'application/json; charset=utf-8',
+                accept: 'application/json',
+                'WWW-Authenticate': 'Basic realm="WS Reconnect Proxy"',
+              });
+              response.end(JSON.stringify({ status: 'failure', value: err }));
+            });
         });
-      } catch (e) {
-        console.log('Error Resolving this', e);
+      } catch (err) {
+        logger.error(`Error while handling custom request ${err}`);
+        response.writeHead(500, {
+          'content-type': 'application/json; charset=utf-8',
+          accept: 'application/json',
+          'WWW-Authenticate': 'Basic realm="WS Reconnect Proxy"',
+        });
+        response.end(JSON.stringify({ status: 'failure', value: err.message }));
       }
       return;
     }

--- a/lib/core/Proxy.js
+++ b/lib/core/Proxy.js
@@ -75,12 +75,12 @@ class Proxy {
         let body = '';
 
         // Read data from the request
-        req.on('data', chunk => {
+        request.on('data', chunk => {
           body += chunk.toString(); // Convert Buffer to string
         });
 
         // When the request ends, process the received data
-        req.on('end', () => {
+        request.on('end', () => {
           body = JSON.parse(body);
           response.writeHead(200, { 'content-type': 'application/json; charset=utf-8', 'accept': 'application/json', 'WWW-Authenticate': 'Basic realm="WS Reconnect Proxy"' });
           const command = body.command
@@ -94,7 +94,7 @@ class Proxy {
           railsContext.outgoingSocket.send(JSON.stringify(command));
 
           //Get the resolved promise and returning it to end user
-          customReqInstance.customRequestList[commandId]?.promise.then((result) => {
+          customReqInstance.customRequestList[commandId].promise.then((result) => {
             response.end(JSON.stringify({ "status": "success", "result": result }));
           });
         });

--- a/lib/core/Proxy.js
+++ b/lib/core/Proxy.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const WebSocket = require('ws');
-const { config, kCleanup, kAddNewContext, HTTPLOG } = require('../config/constants');
+const { config, kCleanup, kAddNewContext, HTTPLOG, customRequestEnabled } = require('../config/constants');
 const logger = require('../util/loggerFactory');
 const Context = require('./Context');
 const {
@@ -65,12 +65,11 @@ class Proxy {
       headers: request.headers,
     };
     logger.info(`${HTTPLOG} Received http request ${options}`);
-    logger.info(`Request ${JSON.stringify(request)}`);
     if (request.url.indexOf('/status') > -1) {
       response.writeHead(200, { 'content-type': 'application/json; charset=utf-8', 'accept': 'application/json', 'WWW-Authenticate': 'Basic realm="WS Reconnect Proxy"' });
       response.end(JSON.stringify({ "status": "Running" }));
       return;
-    } else if (request.url.indexOf('/customRequest') > -1 && request.method == 'POST') {
+    } else if ( customRequestEnabled && request.url.indexOf('/customRequest') > -1 && request.method == 'POST') {
       try {
         logger.info(`Handling request to execute custom command in server`);
         let body = '';
@@ -112,7 +111,6 @@ class Proxy {
       return;
     }
     const proxyReq = http.request(options, (proxyResponse) => {
-      logger.info(`Response ${JSON.stringify(proxyResponse)}`);
       response.writeHead(proxyResponse.statusCode, proxyResponse.headers);
       proxyResponse.pipe(response, {
         end: true,

--- a/lib/core/Proxy.js
+++ b/lib/core/Proxy.js
@@ -77,11 +77,7 @@ class Proxy {
     };
     logger.info(`${HTTPLOG} Received http request ${options}`);
     if (request.url.indexOf('/status') > -1) {
-      response.writeHead(200, {
-        'content-type': 'application/json; charset=utf-8',
-        accept: 'application/json',
-        'WWW-Authenticate': 'Basic realm="WS Reconnect Proxy"',
-      });
+      response.writeHead(200, responseHeaders);
       response.end(JSON.stringify({ status: 'Running' }));
       return;
     } else if (

--- a/lib/core/Proxy.js
+++ b/lib/core/Proxy.js
@@ -94,7 +94,7 @@ class Proxy {
           railsContext.outgoingSocket.send(JSON.stringify(command));
 
           //Get the resolved promise and returning it to end user
-          customReqInstance.customRequestList[commandId].then((result) => {
+          customReqInstance.customRequestList[commandId]?.promise.then((result) => {
             response.end(JSON.stringify({ "status": "success", "result": result }));
           });
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1240,6 +1240,16 @@
         "flat-cache": "^3.0.4"
       }
     },
+    "fill-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "integrity": "sha512-tcgI872xXjwFF4xgQmLxi76GnwJG3g/3isB1l4/G5Z4zrbddGpBjqZCO9oEAcB5wX0Hj/5iQB3toxfO7in1hHA==",
+      "dev": true,
+      "requires": {
+        "is-object": "~1.0.1",
+        "merge-descriptors": "~1.0.0"
+      }
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -1325,6 +1335,12 @@
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "optional": true
+    },
+    "function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -1412,6 +1428,15 @@
         "type-fest": "^0.8.0"
       }
     },
+    "hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.2"
+      }
+    },
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -1484,6 +1509,15 @@
         "binary-extensions": "^2.0.0"
       }
     },
+    "is-core-module": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+      "dev": true,
+      "requires": {
+        "hasown": "^2.0.0"
+      }
+    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1509,6 +1543,12 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "is-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
+      "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
       "dev": true
     },
     "is-plain-obj": {
@@ -1800,6 +1840,12 @@
         "semver": "^6.0.0"
       }
     },
+    "merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "dev": true
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -1869,6 +1915,12 @@
           }
         }
       }
+    },
+    "module-not-found-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "integrity": "sha512-pEk4ECWQXV6z2zjhRZUongnLJNUeGQJ3w6OQ5ctGwD+i5o93qjRQUk2Rt6VdNeu3sEP0AB4LcfvdebpxBRVr4g==",
+      "dev": true
     },
     "mri": {
       "version": "1.1.4",
@@ -2214,6 +2266,12 @@
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
     },
+    "path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
     "path-to-regexp": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
@@ -2347,6 +2405,17 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "proxyquire": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.3.tgz",
+      "integrity": "sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==",
+      "dev": true,
+      "requires": {
+        "fill-keys": "^1.0.2",
+        "module-not-found-error": "^1.0.1",
+        "resolve": "^1.11.1"
+      }
+    },
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -2427,6 +2496,17 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
+    },
+    "resolve": {
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "dev": true,
+      "requires": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      }
     },
     "resolve-from": {
       "version": "5.0.0",
@@ -2662,6 +2742,12 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true
     },
     "table": {
       "version": "6.7.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "eslint": "./node_modules/.bin/eslint *.js",
     "eslint:test": "./node_modules/.bin/eslint test/**/*.js",
     "eslint:fix": "./node_modules/.bin/eslint *.js --fix",
-    "test:eslint:fix": "./node_modules/.bin/eslint test/*.js --fix"
+    "test:eslint:fix": "./node_modules/.bin/eslint test/**/*.js --fix"
   },
   "repository": {
     "type": "git",
@@ -36,6 +36,7 @@
     "mocha": "^9.0.2",
     "nyc": "^15.1.0",
     "prettier": "^2.3.2",
+    "proxyquire": "^2.1.3",
     "sinon": "^11.1.2"
   }
 }

--- a/test/core/customRequestHandler.test.js
+++ b/test/core/customRequestHandler.test.js
@@ -1,0 +1,64 @@
+const { describe, it, beforeEach, afterEach } = require('mocha');
+const { assert } = require('chai');
+const CustomRequestHandler = require('../../lib/core/CustomRequestHandler');
+
+describe('CustomRequestHandler', () => {
+  let originalInstance;
+
+  // Save the original instance of CustomRequestHandler before each test
+  beforeEach(() => {
+    originalInstance = CustomRequestHandler.instance;
+  });
+
+  // Restore the original instance of CustomRequestHandler after each test
+  afterEach(() => {
+    CustomRequestHandler.instance = originalInstance;
+  });
+
+  describe('Singleton behavior', () => {
+    it('should return the same instance when getInstance is called multiple times', () => {
+      const instance1 = CustomRequestHandler.getInstance();
+      const instance2 = CustomRequestHandler.getInstance();
+      assert.strictEqual(instance1, instance2);
+    });
+
+    it('should return the same instance when constrcutor is called multiple times', () => {
+      const instance1 = new CustomRequestHandler();
+      const instance2 = new CustomRequestHandler();
+      assert.strictEqual(instance1, instance2);
+    });
+
+    it('should return a new instance if getInstance is called after resetting the instance', () => {
+      const instance1 = CustomRequestHandler.getInstance();
+      CustomRequestHandler.instance = null;
+      const instance2 = CustomRequestHandler.getInstance();
+      assert.notStrictEqual(instance1, instance2);
+    });
+  });
+
+  describe('addCustomRequest method', () => {
+    it('should add a request to the customRequestList', () => {
+      const customRequestHandler = new CustomRequestHandler();
+      const requestId = '123';
+      customRequestHandler.addCustomRequest(requestId);
+      const list = customRequestHandler.getList();
+      assert.property(list, requestId);
+
+      // Check if the added request has the expected structure
+      const addedRequest = list[requestId];
+      assert.containsAllKeys(addedRequest, ['resolve', 'reject', 'promise']);
+      assert.isFunction(addedRequest.resolve);
+      assert.isFunction(addedRequest.reject);
+      assert.instanceOf(addedRequest.promise, Promise);
+    });
+  });
+
+  describe('getList method', () => {
+    it('should return the customRequestList', () => {
+      const customRequestHandler = new CustomRequestHandler();
+      const list = customRequestHandler.getList();
+      assert.isObject(list);
+      assert.isEmpty(list);
+    });
+  });
+});

--- a/test/core/customRequestHandler.test.js
+++ b/test/core/customRequestHandler.test.js
@@ -55,10 +55,46 @@ describe('CustomRequestHandler', () => {
 
   describe('getList method', () => {
     it('should return the customRequestList', () => {
+      CustomRequestHandler.resetInstance();
       const customRequestHandler = new CustomRequestHandler();
       const list = customRequestHandler.getList();
       assert.isObject(list);
       assert.isEmpty(list);
+    });
+  });
+
+  describe('#isCustomRequestListEmpty', () => {
+    beforeEach(() => {
+      CustomRequestHandler.resetInstance();
+    });
+    it('should return true if the custom request list is empty', () => {
+      const customRequestHandler = new CustomRequestHandler();
+      const result = customRequestHandler.isCustomRequestListEmpty();
+      assert.isTrue(result);
+    });
+
+    it('should return false if the custom request list is not empty', () => {
+      const customRequestHandler = new CustomRequestHandler();
+      customRequestHandler.addCustomRequest('request_1');
+      const result = customRequestHandler.isCustomRequestListEmpty();
+      assert.isFalse(result);
+    });
+
+    it('should handle multiple items in the custom request list', () => {
+      const customRequestHandler = new CustomRequestHandler();
+      customRequestHandler.addCustomRequest('request_1');
+      customRequestHandler.addCustomRequest('request_2');
+      const result = customRequestHandler.isCustomRequestListEmpty();
+      assert.isFalse(result);
+    });
+
+    it('should return true if some properties are directly defined on the object', () => {
+      const customRequestHandler = new CustomRequestHandler();
+      customRequestHandler.customRequestList = Object.create({
+        name: 'inherited',
+      });
+      const result = customRequestHandler.isCustomRequestListEmpty();
+      assert.isTrue(result);
     });
   });
 });

--- a/test/core/outgoingWebSocket.test.js
+++ b/test/core/outgoingWebSocket.test.js
@@ -211,6 +211,7 @@ describe('OutgoingWebSocket', () => {
         const mockCustomRequestHandler = {
           getList: stub().returns({ customRequestId: {} }),
           customRequestList: { customRequestId: { resolve: spy() } },
+          isCustomRequestListEmpty: stub().returns(false),
         };
         customRequestHandler = stub(
           CustomRequestHandler,
@@ -233,6 +234,7 @@ describe('OutgoingWebSocket', () => {
         const mockCustomRequestHandler = {
           getList: stub().returns({ customRequestId: {} }),
           customRequestList: { customRequestId: { resolve: spy() } },
+          isCustomRequestListEmpty: stub().returns(false),
         };
         customRequestHandler = stub(
           CustomRequestHandler,
@@ -256,6 +258,7 @@ describe('OutgoingWebSocket', () => {
         const mockCustomRequestHandler = {
           getList: stub().returns({ customRequestId: {} }),
           customRequestList: { customRequestId: { resolve: spy() } },
+          isCustomRequestListEmpty: stub().returns(false),
         };
         customRequestHandler = stub(
           CustomRequestHandler,
@@ -289,6 +292,25 @@ describe('OutgoingWebSocket', () => {
           }
         );
 
+        outgoingWsCustom = new OutgoingWebSocketWithMock(upstreamUrl, headers);
+        msgSpy = spy();
+        outgoingWsCustom.emit = msgSpy;
+        const msg = '{"id": "customRequestId"}';
+        outgoingWsCustom.messageHandler(msg);
+        assert(msgSpy.calledOnce);
+        assert(msgSpy.calledWith(kMessageReceived, msg));
+      });
+
+      it('should not handle custom requests when no custom requests are pending', () => {
+        const mockCustomRequestHandler = {
+          getList: stub().returns({ customRequestId: {} }),
+          customRequestList: { customRequestId: { resolve: spy() } },
+          isCustomRequestListEmpty: stub().returns(true),
+        };
+        customRequestHandler = stub(
+          CustomRequestHandler,
+          'getInstance'
+        ).returns(mockCustomRequestHandler);
         outgoingWsCustom = new OutgoingWebSocketWithMock(upstreamUrl, headers);
         msgSpy = spy();
         outgoingWsCustom.emit = msgSpy;
@@ -385,6 +407,7 @@ describe('OutgoingWebSocket', () => {
         const mockCustomRequestHandler = {
           getList: stub().returns({ customRequestId: {} }),
           customRequestList: { customRequestId: { reject: spy() } },
+          isCustomRequestListEmpty: stub().returns(false),
         };
         customRequestHandler = stub(
           CustomRequestHandler,
@@ -407,6 +430,7 @@ describe('OutgoingWebSocket', () => {
         const mockCustomRequestHandler = {
           getList: stub().returns({ customRequestId: {} }),
           customRequestList: { customRequestId: { reject: spy() } },
+          isCustomRequestListEmpty: stub().returns(false),
         };
         customRequestHandler = stub(
           CustomRequestHandler,
@@ -430,6 +454,7 @@ describe('OutgoingWebSocket', () => {
         const mockCustomRequestHandler = {
           getList: stub().returns({ customRequestId: {} }),
           customRequestList: { customRequestId: { reject: spy() } },
+          isCustomRequestListEmpty: stub().returns(false),
         };
         customRequestHandler = stub(
           CustomRequestHandler,
@@ -463,6 +488,26 @@ describe('OutgoingWebSocket', () => {
           }
         );
 
+        outgoingWsCustom = new OutgoingWebSocketWithMock(upstreamUrl, headers);
+        msgSpy = spy();
+        outgoingWsCustom.emit = msgSpy;
+        const msg = '{"id": "customRequestId"}';
+        outgoingWsCustom.errorHandler(msg);
+        assert(msgSpy.calledOnce);
+        assert(msgSpy.calledWith(kError, msg));
+      });
+
+      it('should not handle custom requests when no custom requests are pending', () => {
+        // Mock CustomRequestHandler
+        const mockCustomRequestHandler = {
+          getList: stub().returns({ customRequestId: {} }),
+          customRequestList: { customRequestId: { resolve: spy() } },
+          isCustomRequestListEmpty: stub().returns(true),
+        };
+        customRequestHandler = stub(
+          CustomRequestHandler,
+          'getInstance'
+        ).returns(mockCustomRequestHandler);
         outgoingWsCustom = new OutgoingWebSocketWithMock(upstreamUrl, headers);
         msgSpy = spy();
         outgoingWsCustom.emit = msgSpy;

--- a/test/core/outgoingWebSocket.test.js
+++ b/test/core/outgoingWebSocket.test.js
@@ -1,6 +1,7 @@
-const { describe, beforeEach, before, it } = require('mocha');
+const { describe, beforeEach, afterEach, before, it } = require('mocha');
 const { expect, assert } = require('chai');
-const { spy } = require('sinon');
+const { spy, stub } = require('sinon');
+const proxyquire = require('proxyquire');
 const Queue = require('../../lib/core/Queue');
 const OutgoingWebSocket = require('../../lib/core/OutgoingWebSocket');
 const {
@@ -16,8 +17,10 @@ const {
   SERVICE_RESTART,
   RECONNECT,
   kEnableIncomingQueue,
+  kError,
 } = require('../../lib/config/constants');
 const utilFn = require('../../lib/util/util');
+const CustomRequestHandler = require('../../lib/core/CustomRequestHandler');
 
 describe('OutgoingWebSocket', () => {
   let outgoingWs, upstreamUrl, headers;
@@ -174,6 +177,127 @@ describe('OutgoingWebSocket', () => {
       assert(emitSpy.calledOnce);
       assert(emitSpy.calledWith(kEnableIncomingQueue));
     });
+
+    describe('customRequest', () => {
+      let customRequestEnabled;
+      let OutgoingWebSocketWithMock;
+      let outgoingWsCustom;
+      let msgSpy;
+      let customRequestHandler;
+
+      beforeEach(() => {
+        // Stub the environment variable to return 'true'
+        customRequestEnabled = true;
+        // Stub the module with the custom environment variable value
+        OutgoingWebSocketWithMock = proxyquire(
+          '../../lib/core/OutgoingWebSocket',
+          {
+            '../../lib/config/constants': { customRequestEnabled },
+          }
+        );
+
+        outgoingWsCustom = new OutgoingWebSocketWithMock(upstreamUrl, headers);
+        msgSpy = spy();
+        outgoingWsCustom.emit = msgSpy;
+      });
+
+      afterEach(() => {
+        OutgoingWebSocketWithMock = require('../../lib/core/OutgoingWebSocket');
+        customRequestHandler.restore();
+      });
+
+      it('should handle custom requests when enabled and id exists in map', () => {
+        // Mock CustomRequestHandler
+        const mockCustomRequestHandler = {
+          getList: stub().returns({ customRequestId: {} }),
+          customRequestList: { customRequestId: { resolve: spy() } },
+        };
+        customRequestHandler = stub(
+          CustomRequestHandler,
+          'getInstance'
+        ).returns(mockCustomRequestHandler);
+        const msg = '{"id": "customRequestId"}';
+        outgoingWsCustom.messageHandler(msg);
+
+        expect(mockCustomRequestHandler.getList.calledOnce).to.be.true;
+        expect(
+          mockCustomRequestHandler.customRequestList[
+            'customRequestId'
+          ].resolve.calledOnceWith(msg)
+        ).to.be.true;
+        assert.isFalse(msgSpy.called);
+      });
+
+      it('should handle custom requests when enabled and id don"t exists in map', () => {
+        // Mock CustomRequestHandler
+        const mockCustomRequestHandler = {
+          getList: stub().returns({ customRequestId: {} }),
+          customRequestList: { customRequestId: { resolve: spy() } },
+        };
+        customRequestHandler = stub(
+          CustomRequestHandler,
+          'getInstance'
+        ).returns(mockCustomRequestHandler);
+        const msg = '{"id": "nonExistingId"}';
+        outgoingWsCustom.messageHandler(msg);
+
+        expect(mockCustomRequestHandler.getList.calledOnce).to.be.true;
+        expect(mockCustomRequestHandler.customRequestList['nonExistingId']).to
+          .be.undefined;
+        assert(msgSpy.calledOnce);
+        assert(msgSpy.calledWith(kMessageReceived, msg));
+      });
+
+      it('catches error when JSON parsing fails and emits the message', () => {
+        // Mock CustomRequestHandler
+        const loggerStub = {
+          error: stub(),
+        };
+        const mockCustomRequestHandler = {
+          getList: stub().returns({ customRequestId: {} }),
+          customRequestList: { customRequestId: { resolve: spy() } },
+        };
+        customRequestHandler = stub(
+          CustomRequestHandler,
+          'getInstance'
+        ).returns(mockCustomRequestHandler);
+        OutgoingWebSocketWithMock = proxyquire(
+          '../../lib/core/OutgoingWebSocket',
+          {
+            '../../lib/config/constants': { customRequestEnabled },
+            '../../lib/util/loggerFactory': loggerStub,
+          }
+        );
+
+        outgoingWsCustom = new OutgoingWebSocketWithMock(upstreamUrl, headers);
+        msgSpy = spy();
+        outgoingWsCustom.emit = msgSpy;
+        const msg = 'invalid_json';
+        outgoingWsCustom.messageHandler(msg);
+        assert.isTrue(loggerStub.error.calledOnce);
+        assert.match(loggerStub.error.args[0][0], /Error parsing JSON/);
+        assert(msgSpy.calledOnce);
+        assert(msgSpy.calledWith(kMessageReceived, msg));
+      });
+
+      it('should not handle custom requests when disabled', () => {
+        customRequestEnabled = false;
+        OutgoingWebSocketWithMock = proxyquire(
+          '../../lib/core/OutgoingWebSocket',
+          {
+            '../../lib/config/constants': { customRequestEnabled },
+          }
+        );
+
+        outgoingWsCustom = new OutgoingWebSocketWithMock(upstreamUrl, headers);
+        msgSpy = spy();
+        outgoingWsCustom.emit = msgSpy;
+        const msg = '{"id": "customRequestId"}';
+        outgoingWsCustom.messageHandler(msg);
+        assert(msgSpy.calledOnce);
+        assert(msgSpy.calledWith(kMessageReceived, msg));
+      });
+    });
   });
 
   describe('#closeHandler', () => {
@@ -226,6 +350,127 @@ describe('OutgoingWebSocket', () => {
       outgoingWs.emit = errSpy;
       outgoingWs.errorHandler('SOME ERROR');
       assert(errSpy.calledOnce);
+    });
+
+    describe('customRequest', () => {
+      let customRequestEnabled;
+      let OutgoingWebSocketWithMock;
+      let outgoingWsCustom;
+      let msgSpy;
+      let customRequestHandler;
+
+      beforeEach(() => {
+        // Stub the environment variable to return 'true'
+        customRequestEnabled = true;
+        // Stub the module with the custom environment variable value
+        OutgoingWebSocketWithMock = proxyquire(
+          '../../lib/core/OutgoingWebSocket',
+          {
+            '../../lib/config/constants': { customRequestEnabled },
+          }
+        );
+
+        outgoingWsCustom = new OutgoingWebSocketWithMock(upstreamUrl, headers);
+        msgSpy = spy();
+        outgoingWsCustom.emit = msgSpy;
+      });
+
+      afterEach(() => {
+        OutgoingWebSocketWithMock = require('../../lib/core/OutgoingWebSocket');
+        customRequestHandler.restore();
+      });
+
+      it('should reject custom requests when enabled and id exists in map', () => {
+        // Mock CustomRequestHandler
+        const mockCustomRequestHandler = {
+          getList: stub().returns({ customRequestId: {} }),
+          customRequestList: { customRequestId: { reject: spy() } },
+        };
+        customRequestHandler = stub(
+          CustomRequestHandler,
+          'getInstance'
+        ).returns(mockCustomRequestHandler);
+        const msg = '{"id": "customRequestId"}';
+        outgoingWsCustom.errorHandler(msg);
+
+        expect(mockCustomRequestHandler.getList.calledOnce).to.be.true;
+        expect(
+          mockCustomRequestHandler.customRequestList[
+            'customRequestId'
+          ].reject.calledOnceWith(msg)
+        ).to.be.true;
+        assert.isFalse(msgSpy.called);
+      });
+
+      it('should not reject custom requests when enabled and id don"t exists in map', () => {
+        // Mock CustomRequestHandler
+        const mockCustomRequestHandler = {
+          getList: stub().returns({ customRequestId: {} }),
+          customRequestList: { customRequestId: { reject: spy() } },
+        };
+        customRequestHandler = stub(
+          CustomRequestHandler,
+          'getInstance'
+        ).returns(mockCustomRequestHandler);
+        const msg = '{"id": "nonExistingId"}';
+        outgoingWsCustom.errorHandler(msg);
+
+        expect(mockCustomRequestHandler.getList.calledOnce).to.be.true;
+        expect(mockCustomRequestHandler.customRequestList['nonExistingId']).to
+          .be.undefined;
+        assert(msgSpy.calledOnce);
+        assert(msgSpy.calledWith(kError, msg));
+      });
+
+      it('catches error when JSON parsing fails and emits the error', () => {
+        // Mock CustomRequestHandler
+        const loggerStub = {
+          error: stub(),
+        };
+        const mockCustomRequestHandler = {
+          getList: stub().returns({ customRequestId: {} }),
+          customRequestList: { customRequestId: { reject: spy() } },
+        };
+        customRequestHandler = stub(
+          CustomRequestHandler,
+          'getInstance'
+        ).returns(mockCustomRequestHandler);
+        OutgoingWebSocketWithMock = proxyquire(
+          '../../lib/core/OutgoingWebSocket',
+          {
+            '../../lib/config/constants': { customRequestEnabled },
+            '../../lib/util/loggerFactory': loggerStub,
+          }
+        );
+
+        outgoingWsCustom = new OutgoingWebSocketWithMock(upstreamUrl, headers);
+        msgSpy = spy();
+        outgoingWsCustom.emit = msgSpy;
+        const msg = 'invalid_json';
+        outgoingWsCustom.errorHandler(msg);
+        assert.isTrue(loggerStub.error.calledOnce);
+        assert.match(loggerStub.error.args[0][0], /Error parsing JSON/);
+        assert(msgSpy.calledOnce);
+        assert(msgSpy.calledWith(kError, msg));
+      });
+
+      it('should not handle custom requests when disabled', () => {
+        customRequestEnabled = false;
+        OutgoingWebSocketWithMock = proxyquire(
+          '../../lib/core/OutgoingWebSocket',
+          {
+            '../../lib/config/constants': { customRequestEnabled },
+          }
+        );
+
+        outgoingWsCustom = new OutgoingWebSocketWithMock(upstreamUrl, headers);
+        msgSpy = spy();
+        outgoingWsCustom.emit = msgSpy;
+        const msg = '{"id": "customRequestId"}';
+        outgoingWsCustom.errorHandler(msg);
+        assert(msgSpy.calledOnce);
+        assert(msgSpy.calledWith(kError, msg));
+      });
     });
   });
 

--- a/test/core/proxy.test.js
+++ b/test/core/proxy.test.js
@@ -1,11 +1,13 @@
 const Proxy = require('../../lib/core/Proxy');
 const Context = require('../../lib/core/Context');
-const { describe, it, before, after } = require('mocha');
-const { expect } = require('chai');
-const { spy } = require('sinon');
+const { describe, it, before, after, beforeEach, afterEach } = require('mocha');
+const { expect, assert: assertChai } = require('chai');
+const { spy, stub, restore } = require('sinon');
 const { kAddNewContext } = require('../../lib/config/constants');
 const http = require('http');
 const { assert } = require('console');
+const proxyquire = require('proxyquire');
+const CustomRequestHandler = require('../../lib/core/CustomRequestHandler');
 
 describe('Proxy', () => {
   before(() => {
@@ -27,7 +29,7 @@ describe('Proxy', () => {
 
     this.response = {
       writeHead: spy(),
-      end: spy()
+      end: spy(),
     };
 
     this.proxy = new Proxy();
@@ -45,6 +47,221 @@ describe('Proxy', () => {
     requestSpy.restore();
   });
 
+  describe('customRequest', () => {
+    let customRequestEnabled;
+    let ProxyWithMock;
+    let proxyWsCustom;
+    let responseMock;
+    let requestMock;
+
+    beforeEach(() => {
+      // Stub the environment variable to return 'true'
+      customRequestEnabled = true;
+      // Stub the module with the custom environment variable value
+      ProxyWithMock = proxyquire('../../lib/core/Proxy', {
+        '../../lib/config/constants': {
+          customRequestEnabled,
+          config: {
+            workers: 1,
+            port: 8000,
+            hostname: '127.0.0.1',
+            upstream: 'ws://localhost:8000',
+            retryDelay: 10000,
+            closeTimer: 15000,
+            enableInstrumentation: true,
+            instrumentationTimer: 60000,
+          },
+        },
+      });
+      proxyWsCustom = new ProxyWithMock();
+      stub(http, 'request');
+      // Create mocks for request and response objects
+      responseMock = {
+        writeHead: stub(),
+        end: stub(),
+      };
+      requestMock = new http.IncomingMessage();
+    });
+
+    afterEach(() => {
+      restore();
+      proxyWsCustom.httpServer.close();
+      proxyWsCustom.server.close();
+    });
+
+    it('should handle custom request', (done) => {
+      // Set up request object
+      stub(CustomRequestHandler, 'getInstance').returns({
+        addCustomRequest: stub().returns({
+          promise: Promise.resolve(),
+        }),
+        customRequestList: {
+          123: {
+            promise: Promise.resolve(),
+          },
+        },
+      });
+      requestMock.url = '/customRequest';
+      requestMock.method = 'POST';
+
+      // Stub the 'on' method to capture 'data' and 'end' event callbacks
+      const requestOnStub = stub();
+      requestOnStub
+        .withArgs('data')
+        .callsArgWith(
+          1,
+          JSON.stringify({ command: { id: '123', command: 'mockCommand' } })
+        );
+      requestOnStub.withArgs('end').callsArg(1);
+      requestMock.on = requestOnStub;
+
+      // Stub the 'send' method of the outgoing socket
+      const outgoingSocketStub = {
+        send: stub(),
+      };
+
+      // Stub the 'getContexts' method to return a mock context
+      const getContextsStub = stub().returns(
+        new Map([['mockContextId', { outgoingSocket: outgoingSocketStub }]])
+      );
+
+      // Stub the 'contexts' property of the class instance to return the mock context
+      stub(proxyWsCustom, 'contexts').get(getContextsStub);
+      proxyWsCustom.requestHandler(requestMock, responseMock);
+      assertChai.isTrue(
+        CustomRequestHandler.getInstance().addCustomRequest.calledOnceWith(
+          '123'
+        )
+      );
+      assertChai.isTrue(
+        outgoingSocketStub.send.calledOnceWith(
+          JSON.stringify({ id: '123', command: 'mockCommand' })
+        )
+      );
+
+      // Simulate resolution of the promise
+      const resolveSpy = spy();
+      CustomRequestHandler.getInstance().customRequestList['123'].promise.then(
+        resolveSpy
+      );
+      setTimeout(() => {
+        assertChai.isTrue(
+          responseMock.writeHead.calledOnceWith(200, {
+            'content-type': 'application/json; charset=utf-8',
+            accept: 'application/json',
+            'WWW-Authenticate': 'Basic realm="WS Reconnect Proxy"',
+          })
+        );
+        assertChai.isTrue(
+          responseMock.end.calledOnceWith(
+            JSON.stringify({ status: 'success', value: undefined })
+          )
+        );
+        done();
+      }, 10); // Delay added to allow promise resolution
+    });
+
+    it('should handle error responses', (done) => {
+      stub(CustomRequestHandler, 'getInstance').returns({
+        addCustomRequest: stub().returns({
+          promise: Promise.resolve(),
+        }),
+        customRequestList: {
+          123: {
+            promise: Promise.reject(),
+          },
+        },
+      });
+      // Set up request object
+      requestMock.url = '/customRequest';
+      requestMock.method = 'POST';
+
+      // Stub the 'on' method to capture 'data' and 'end' event callbacks
+      const requestOnStub = stub();
+      requestOnStub
+        .withArgs('data')
+        .callsArgWith(
+          1,
+          JSON.stringify({ command: { id: '123', command: 'mockCommand' } })
+        );
+      requestOnStub.withArgs('end').callsArg(1);
+      requestMock.on = requestOnStub;
+
+      // Stub the 'send' method of the outgoing socket
+      const outgoingSocketStub = {
+        send: stub(),
+      };
+
+      // Stub the 'getContexts' method to return a mock context
+      const getContextsStub = stub().returns(
+        new Map([['mockContextId', { outgoingSocket: outgoingSocketStub }]])
+      );
+
+      // Stub the 'contexts' property of the class instance to return the mock context
+      stub(proxyWsCustom, 'contexts').get(getContextsStub);
+      proxyWsCustom.requestHandler(requestMock, responseMock);
+      assertChai.isTrue(
+        CustomRequestHandler.getInstance().addCustomRequest.calledOnceWith(
+          '123'
+        )
+      );
+      assertChai.isTrue(
+        outgoingSocketStub.send.calledOnceWith(
+          JSON.stringify({ id: '123', command: 'mockCommand' })
+        )
+      );
+
+      // Simulate resolution of the promise
+      const rejectSpy = spy();
+      CustomRequestHandler.getInstance().customRequestList['123'].promise.catch(
+        rejectSpy
+      );
+      setTimeout(() => {
+        assertChai.isTrue(
+          responseMock.writeHead.calledOnceWith(500, {
+            'content-type': 'application/json; charset=utf-8',
+            accept: 'application/json',
+            'WWW-Authenticate': 'Basic realm="WS Reconnect Proxy"',
+          })
+        );
+        assertChai.isTrue(
+          responseMock.end.calledOnceWith(
+            JSON.stringify({ status: 'failure', value: undefined })
+          )
+        );
+        done();
+      }, 10); // Delay added to allow promise resolution
+    });
+
+    it('catches all the errors in customRequest and returns 500', () => {
+      // Set up request object for custom request
+      requestMock.url = '/customRequest';
+      requestMock.method = 'POST';
+
+      // Stub the 'on' method to capture 'data' event callback and throw an error
+      const requestOnStub = stub();
+      requestOnStub.withArgs('data').throws(new Error('Custom error message'));
+      requestMock.on = requestOnStub;
+
+      // Call the method to test
+      proxyWsCustom.requestHandler(requestMock, responseMock);
+
+      // Assertions for the outer catch block
+      assertChai.isTrue(
+        responseMock.writeHead.calledOnceWith(500, {
+          'content-type': 'application/json; charset=utf-8',
+          accept: 'application/json',
+          'WWW-Authenticate': 'Basic realm="WS Reconnect Proxy"',
+        })
+      );
+      assertChai.isTrue(
+        responseMock.end.calledOnceWith(
+          JSON.stringify({ status: 'failure', value: 'Custom error message' })
+        )
+      );
+    });
+  });
+
   it('should handle request', () => {
     const request = {
       pipe: spy(),
@@ -55,9 +272,17 @@ describe('Proxy', () => {
     };
     this.proxy.requestHandler(request, this.response);
     expect(this.response.writeHead.calledOnce).to.be.equal(true);
-    assert(this.response.writeHead.calledWith(200, {'content-type': 'application/json; charset=utf-8', 'accept': 'application/json', 'WWW-Authenticate': 'Basic realm="WS Reconnect Proxy"'}));
+    assert(
+      this.response.writeHead.calledWith(200, {
+        'content-type': 'application/json; charset=utf-8',
+        accept: 'application/json',
+        'WWW-Authenticate': 'Basic realm="WS Reconnect Proxy"',
+      })
+    );
     expect(this.response.end.calledOnce).to.be.equal(true);
-    assert(this.response.writeHead.calledWith(JSON.stringify({'status' : 'Running'})));
+    assert(
+      this.response.writeHead.calledWith(JSON.stringify({ status: 'Running' }))
+    );
   });
 
   it('should set connection id', () => {

--- a/test/core/proxy.test.js
+++ b/test/core/proxy.test.js
@@ -8,6 +8,11 @@ const http = require('http');
 const { assert } = require('console');
 const proxyquire = require('proxyquire');
 const CustomRequestHandler = require('../../lib/core/CustomRequestHandler');
+const responseHeaders = {
+  'content-type': 'application/json; charset=utf-8',
+  accept: 'application/json',
+  'WWW-Authenticate': 'Basic realm="WS Reconnect Proxy"',
+};
 
 describe('Proxy', () => {
   before(() => {
@@ -146,11 +151,7 @@ describe('Proxy', () => {
       );
       setTimeout(() => {
         assertChai.isTrue(
-          responseMock.writeHead.calledOnceWith(200, {
-            'content-type': 'application/json; charset=utf-8',
-            accept: 'application/json',
-            'WWW-Authenticate': 'Basic realm="WS Reconnect Proxy"',
-          })
+          responseMock.writeHead.calledOnceWith(200, responseHeaders)
         );
         assertChai.isTrue(
           responseMock.end.calledOnceWith(
@@ -218,11 +219,7 @@ describe('Proxy', () => {
       );
       setTimeout(() => {
         assertChai.isTrue(
-          responseMock.writeHead.calledOnceWith(500, {
-            'content-type': 'application/json; charset=utf-8',
-            accept: 'application/json',
-            'WWW-Authenticate': 'Basic realm="WS Reconnect Proxy"',
-          })
+          responseMock.writeHead.calledOnceWith(500, responseHeaders)
         );
         assertChai.isTrue(
           responseMock.end.calledOnceWith(
@@ -248,11 +245,7 @@ describe('Proxy', () => {
 
       // Assertions for the outer catch block
       assertChai.isTrue(
-        responseMock.writeHead.calledOnceWith(500, {
-          'content-type': 'application/json; charset=utf-8',
-          accept: 'application/json',
-          'WWW-Authenticate': 'Basic realm="WS Reconnect Proxy"',
-        })
+        responseMock.writeHead.calledOnceWith(500, responseHeaders)
       );
       assertChai.isTrue(
         responseMock.end.calledOnceWith(
@@ -273,11 +266,7 @@ describe('Proxy', () => {
     this.proxy.requestHandler(request, this.response);
     expect(this.response.writeHead.calledOnce).to.be.equal(true);
     assert(
-      this.response.writeHead.calledWith(200, {
-        'content-type': 'application/json; charset=utf-8',
-        accept: 'application/json',
-        'WWW-Authenticate': 'Basic realm="WS Reconnect Proxy"',
-      })
+      this.response.writeHead.calledWith(200, responseHeaders)
     );
     expect(this.response.end.calledOnce).to.be.equal(true);
     assert(


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
These changes allow us to execute the custom requests in existing playwright session, playwright maintains the command map on  client side and if any command mismatch is found it close down the connection. Using proxy we intercept the the custom requests which are triggered by other client on same playwright connection. We maintain the singleton map of such commands and on receiving response from playwright server we instead of sending playwright client proxy it to client who executed the customRequest. 

As a part of controlling the codeflow in case something goes wrong we have added a flag customRequestEnabled, which will be governed via redis flag from rails. It is by default false so that our code don't run for hub level proxy as env variable will not be set. The env variable will be set only from terminal side code so only there it will get enabled.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tested it on staging environment
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
